### PR TITLE
Revise assignment identification

### DIFF
--- a/src/Parse/Visitor/FunctionLikeFindingVisitor.php
+++ b/src/Parse/Visitor/FunctionLikeFindingVisitor.php
@@ -7,6 +7,7 @@ namespace Smeghead\PhpVariableHardUsage\Parse\Visitor;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\FunctionLike;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Node\Stmt\Class_;
@@ -31,8 +32,10 @@ class FunctionLikeFindingVisitor extends FindingVisitor {
             // Record class name
             $this->currentNamespace = $node->name ? $node->name->name : null;
         }
-
-        if ($node instanceof Assign || $node instanceof AssignOp) {
+        if ($node instanceof Assign ||
+            $node instanceof AssignOp ||
+            $node instanceof AssignRef
+        ) {
             $node->var->setAttribute('assigned', true); // Mark as assigned
         }
         if ($node instanceof FunctionLike) {

--- a/test/VariableParserTest.php
+++ b/test/VariableParserTest.php
@@ -107,7 +107,7 @@ class VariableParserTest extends TestCase
         $functions = $result->functions;
         $this->assertCount(1, $functions);
         $this->assertSame('assignFunction', $functions[0]->name);
-        $this->assertCount(14, $functions[0]->getVariables());
+        $this->assertCount(15, $functions[0]->getVariables());
 
         $vars = $functions[0]->getVariables();
         $this->assertSame('num', $vars[0]->name);
@@ -152,6 +152,9 @@ class VariableParserTest extends TestCase
         $this->assertSame('num', $vars[13]->name);
         $this->assertSame(18, $vars[13]->lineNumber);
         $this->assertSame(true, $vars[13]->assigned);
+        $this->assertSame('num', $vars[14]->name);
+        $this->assertSame(19, $vars[14]->lineNumber);
+        $this->assertSame(true, $vars[14]->assigned);
     }
 
     public function testInterpolatedStringFunction(): void

--- a/test/fixtures/assign_operator.php
+++ b/test/fixtures/assign_operator.php
@@ -16,4 +16,5 @@ function assignFunction(): void
     $num >>= 1; // 16行目
     $num .= 1; // 17行目
     $num ??= 1; // 18行目
+    $num =& f(); // 19行目
 }


### PR DESCRIPTION
If it is necessary to consider '=&' in the calculation of coefficients, AssignRef should be considered as assignment.